### PR TITLE
hotfix: fix helicopter spawner and add direction to markers

### DIFF
--- a/OPCB/functions/helispawner/spawn_heli_vehicle.sqf
+++ b/OPCB/functions/helispawner/spawn_heli_vehicle.sqf
@@ -20,7 +20,7 @@ if(_loadout != -1) then  {
 	
 	_nObjects= nearestObjects [markerPos "aircraft_spawner", ["LandVehicle", "Thing", "Static", "Ship", "Air", "Man"], 7];
 	
-	if (count _nObjects == 1) then {
+	if (count _nObjects == 0) then {
 
 		if ((toUpper _vehicle) in OPCB_econ_vehicleAirAttackTypes) then {
 		  if (MaxAttackHelis != 2) then {

--- a/mission-files/Sahrani/mission.sqm
+++ b/mission-files/Sahrani/mission.sqm
@@ -17013,6 +17013,7 @@ class Mission
 			text="Aircraft Spawner";
 			type="b_plane";
 			colorName="ColorWEST";
+			angle=311.5285;
 			id=100;
 			atlOffset=40.257999;
 		};
@@ -29040,6 +29041,7 @@ class Mission
 			position[]={19160.039,11.97,13965.897};
 			name="marker_2";
 			type="b_maint";
+			angle=41.974834;
 			id=975;
 		};
 		class Item326


### PR DESCRIPTION
fix helicopter spawner: the helipad was removed, so now we check if there is no object in the area.
add direction to the markers: helicopter marker facing direction of runway, and gate of hangar  for vehicles